### PR TITLE
updates to seurat doublet pipeline and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ code can be found at [read the docs](http://single-cell.readthedocs.io/)
 
 - [ ] [Overview of the seurat cluster-3 pipeline](docs/pipelines/seurat_cluster-3.md)
 
+## seurat doublet-4
+
+- [ ] [Overview of the seurat doublet-4 pipeline](docs/pipelines/seurat_doublet-4.md)
+
 # Project Info
 
 - [ ] [Contributors](docs/project_info/Contributing.rst)

--- a/docs/pipelines/seurat_doublet-4.md
+++ b/docs/pipelines/seurat_doublet-4.md
@@ -1,0 +1,55 @@
+## seurat doublet-4
+
+pipeline_doublet-4.py overview:  
+- Make directory called Doublet_Figures.dir
+- Run the R script doublet_finder.R
+- Run the Rmd Doublets.Rmd to generate Doublets.html
+
+**Commands:**
+> scflow seurat doublet-4 config  
+> nohup scflow seurat doublet-4 make full -v5
+
+
+### doublet_finder.R
+
+**Inputs:**  
+Clustered filtered Seurat object created by seurat_cluster.R
+
+**Options:**
+Defined in pipeline.yml
+
+| Option | Description
+|---------|-------------|
+|	-i -input |	input files
+|	-s --sample	|sample name
+
+**Steps:**
+- Read in the seurat object
+- Convert to SingleCellExperiment object
+- Call doublets with scDblfinder
+- Save a table describing the number of doublets identified
+- Save RDS object
+
+**Outputs:**
+- Table (.csv) describing number of doublets identified
+- RDS object including doublet information
+
+### Doublets.Rmd
+
+**Inputs:**  
+Clustered filtered doublets Seurat object created by doublet_finder.R
+
+**Steps:**
+- Read in the seurat object
+- Normalise the data
+- Find Variable features
+- Scale the data
+- Perform PCA
+- Find Neighbours
+- Find Clusters
+- Generat UMAP
+- Plot UMAP displaying doublets and singlets
+
+**Outputs:**
+- UMAP (.eps) displaying doublets and singlets
+- Doublets.html

--- a/scpipelines/seurat/R/doublet_finder.R
+++ b/scpipelines/seurat/R/doublet_finder.R
@@ -23,15 +23,10 @@ filtered_seurat_object <- readRDS(seurat_filtered_rds)
 sce <- as.SingleCellExperiment(filtered_seurat_object)
 sce <- scDblFinder(sce, dbr=0.1)
 
-
+# save output on number of doublets identified
 outfile <- paste0("Doublet_Figures.dir/", opt$sample, "_doublets.csv")
 
 write.csv(table(sce$scDblFinder.class), file=outfile, row.names = F)
 
-sce.seurat <- as.Seurat(sce, counts = "counts", data = "logcounts")
-
-metadata <- sce.seurat@meta.data
-
-out_meta <- paste0("Doublet_Figures.dir/", opt$sample, "_metadata.csv")
-
-write.csv(metadata, file=out_meta, row.names = T)
+# save the RDS file
+saveRDS(sce, gsub("SAMPLE_FILE",sample_name ,"RDS_objects.dir/SAMPLE_FILE_filtered_clustered_doublet_SeuratObject.rds"))

--- a/scpipelines/seurat/pipeline_doublet-4/Rmarkdown/Doublets.Rmd
+++ b/scpipelines/seurat/pipeline_doublet-4/Rmarkdown/Doublets.Rmd
@@ -25,22 +25,8 @@ sample_files <- str_replace(Sys.glob("kallisto.dir/*"), "kallisto.dir/", "")
 
 ```{r}
 for (i in sample_files){
-  name <- paste0("RDS_objects.dir/", i, "_filtered_SeuratObject.rds")
+  name <- paste0("RDS_objects.dir/", i, "_filtered_clustered_doublet_SeuratObject.rds")
   so <- readRDS(name)
-  assign(paste("so", i, sep = "."), so)
-}
-```
-
-
-# add doublet metadata to so meta.data
-
-```{r}
-for (i in sample_files){
-  so <- get(gsub("SAMPLE_FILE",i , "so.SAMPLE_FILE"))
-  metadata <- read.csv(paste0("Doublet_Figures.dir/", i, "_metadata.csv"), row.names = 1)
-  
-  so@meta.data <- metadata
-  so@meta.data
   assign(paste("so", i, sep = "."), so)
 }
 ```
@@ -90,5 +76,3 @@ print(DimPlot(filtered_seurat_object, reduction="umap", pt.size = 0.5))
 }
 ```
 
-# need to import metadata with the doublet and overwrte that with the so
-# then plot the doublet numbers in plot and umap


### PR DESCRIPTION
Previous steps were:
seurat_doublet.R
- convert sce to so 
- save metadata
Doublets.Rmd
- open so
- assign saved metadata

I have changed it so that the sce is saved as .rds in seurat_doublet.R then that same object is imported in Doublets.Rmd
No reassigning of metadata required.

Added documentation page for seurat_doublet.py

