### PR TITLE
added time parameter and fixed error that prevented run_fastqc from running

### DIFF
--- a/scpipelines/pipeline_quantcells.py
+++ b/scpipelines/pipeline_quantcells.py
@@ -199,7 +199,7 @@ def run_kallisto_bus(infiles, outfile):
 
     job_memory = PARAMS['bustools_memory']
 
-    P.run(statement)
+    P.run(statement, job_options='-t 167:00:00')
 
 
 @jobs_limit(1)
@@ -287,7 +287,7 @@ def barnyard_plot(infile, outfile):
     P.run(statement)
 
 
-@follows(bustools_count, barnyard_plot)
+@follows(bustools_count, barnyard_plot, run_fastqc)
 def full():
     pass
 

--- a/scpipelines/pipeline_quantnuclei.py
+++ b/scpipelines/pipeline_quantnuclei.py
@@ -232,7 +232,7 @@ def run_kallisto_bus(infiles, outfile):
 
     job_memory = '100G'
 
-    P.run(statement)
+    P.run(statement, job_options='-t 167:00:00')
 
 
 @transform(run_kallisto_bus,


### PR DESCRIPTION
pipeline_quantnuclei.py and pipeline_quantcells.py Time parameter added to prevent jobs crashing out after 3 days on the CCB cluster
pipeline_quantcells.py Added run_fastqc to the @follows statement on line 290, otherwise the run_fastqc did not run.
